### PR TITLE
Remove feed format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,15 @@ on a single device. There is a separate [fusion identity] protocol
 that only deals with how to relate multiple devices to a single
 identity. This spec here is not for that use-case.
 
-Meta feeds will use a specialized [feed
-format](https://github.com/ssb-ngi-pointer/bipfy-badger-spec) that
-aims be very easy to implement. The aim is that this will make it
-easier for implementations which do not need or want to support
-the classical SSB format.
+Meta feeds will use a specialized [bendy butt feed format] that aims
+be very easy to implement. The aim is that this will make it easier
+for implementations which do not need or want to support the classical
+SSB format.
 
 ## Example of a meta feed
 
-Here is an an example of a meta feed with 2 sub feeds: one for `main` social data and another one 
-for `application-x` in a different format.
+Here is an an example of a meta feed with 2 sub feeds: one for `main`
+social data and another one for `application-x` in a different format.
 
 ![Diagram](./metafeed-example1.svg)
 <details>
@@ -51,9 +50,8 @@ feeds:
 ```js
 { 
   type: 'metafeed/add', 
-  feedformat: 'classic', 
   feedpurpose: 'main', 
-  subfeed: '@main',
+  subfeed: '@main.ed25519',
   tangles: {
     metafeed: { root: null, previous: null }
   },
@@ -61,25 +59,26 @@ feeds:
 },
 { 
   type: 'metafeed/add', 
-  feedformat: 'bamboo', 
   feedpurpose: 'application-x', 
-  subfeed: '@application-x',
+  subfeed: '@application-x.bamboo',
   //...
 }
 ```
 
-Initially the meta feed spec supports two operations: `add` and `tombstone`.
-**Note**, signatures (see key management section) are left out in the examples here.
+Initially the meta feed spec supports two operations: `add` and
+`tombstone`.  **Note**, signatures (see key management section) are
+left out in the examples here.
 
 Tombstoning means that the feed is no longer part of the meta feed.
-Whether or not the sub feed itself is tombstoned is a separate concern.
+Whether or not the sub feed itself is tombstoned is a separate
+concern.
 
 Example tombstone message:
 
 ```js
 { 
   type: 'metafeed/tombstone',
-  subfeed: '@applications',
+  subfeed: '@application-x.bamboo',
   reason: '',
   tangles: {
     metafeed: { root: "%addmsg", previous: "%addmsg" }
@@ -87,7 +86,8 @@ Example tombstone message:
 }
 ```
 
-Updating the metadata on a sub feed which is a member of a meta feed is currently not supported.
+Updating the metadata on a sub feed which is a member of a meta feed
+is currently not supported.
 
 ## Applications example
 
@@ -113,16 +113,14 @@ digraph Applications {
 ```js
 { 
   type: 'metafeed/add', 
-  feedformat: 'classic', 
   feedpurpose: 'gathering' 
-  subfeed: '@app1',
+  subfeed: '@app1.ed25519',
   ...
 },
 { 
   type: 'metafeed/add', 
-  feedformat: 'classic', 
   feedpurpose: 'chess' 
-  subfeed: '@app2',
+  subfeed: '@app2.ed25519',
   ...
 }
 ```
@@ -134,8 +132,8 @@ as the feed. Here instead we want to decouple identity and feeds.
 
 ### Existing SSB identity
 
-To generate a meta feed and link it to an existing `main` feed, first a seed
-is generated:
+To generate a meta feed and link it to an existing `main` feed, first
+a seed is generated:
 
 ```js
 const seed = crypto.randomBytes(32)
@@ -167,31 +165,30 @@ We also encrypt the seed as a private message to the `main` feed.
 By doing so we allow the existing feed to reconstruct the meta feed and
 all sub feeds from this seed.
 
-Then the meta feed is linked with the existing `main` feed using a new message on
-the meta feed signed by both the `main` feed and the meta feed. For
-details this see the [feed format](https://github.com/ssb-ngi-pointer/bipfy-badger-spec).
+Then the meta feed is linked with the existing `main` feed using a new
+message on the meta feed signed by both the `main` feed and the meta
+feed. For details this see [bendy butt feed format].
 
 ```js
 {
   type: 'metafeed/add',
-  feedformat: 'clasic',
   feedpurpose: 'main',
-  subfeed: '@main',
-  metafeed: '@mf', 
+  subfeed: '@main.ed25519',
+  metafeed: '@mf.bbfeed-v1', 
   tangles: {
     metafeed: { root: null, previous: null }
   }
 }
 ```
 
-In order for existing applications to know that the existing feed supports meta
-feeds, a special message is created on the `main` feed:
+In order for existing applications to know that the existing feed
+supports meta feeds, a special message is created on the `main` feed:
 
 ```js
 { 
   content: {
     type: 'metafeed/announce',
-    metafeed: '@mf',
+    metafeed: '@mf.bbfeed-v1',
     tangles: {
       metafeed: { root: null, previous: null }
     }
@@ -199,24 +196,25 @@ feeds, a special message is created on the `main` feed:
 }
 ```
 
-A feed can only have **one** meta feed. If for whatever reason an existing
-meta feed needs to be superseed, a new message is created pointing to
-the previous `metafeed/announce` message via the tangle.
+A feed can only have **one** meta feed. If for whatever reason an
+existing meta feed needs to be superseed, a new message is created
+pointing to the previous `metafeed/announce` message via the tangle.
 
 ### New SSB identity
 
-A new identity also starts by constructing a seed. From this seed both the
-meta feed keys and the main feed keys are generated. The main should
-use the info: `ssb-meta-feed-seed-v1:<base64 encoded nonce>` and the `nonce` is also published as part of the `metafeed/add` message on the meta feed.
+A new identity also starts by constructing a seed. From this seed both
+the meta feed keys and the main feed keys are generated. The main
+should use the info: `ssb-meta-feed-seed-v1:<base64 encoded nonce>`
+and the `nonce` is also published as part of the `metafeed/add`
+message on the meta feed.
 
 ```js
 {
   type: 'metafeed/add',
-  feedformat: 'clasic',
   feedpurpose: 'main',
-  subfeed: '@main',
-  metafeed: '@mf', 
-  nonce: '<random_32_bit>',
+  subfeed: '@main.ed25519',
+  metafeed: '@mf.bbfeed-v1', 
+  nonce: '<random_32_bytes_as_base64>',
   tangles: {
     metafeed: { root: null, previous: null }
   }
@@ -322,3 +320,4 @@ CFT suggested the use of meta feeds
 [BIP32-Ed25519]: https://github.com/wallet-io/bip32-ed25519/blob/master/doc/Ed25519_BIP.pdf
 [ssb-secure-partial-replication]: https://github.com/ssb-ngi-pointer/ssb-secure-partial-replication
 [fusion identity]: https://github.com/ssb-ngi-pointer/fusion-identity-spec/
+[bendy butt feed format]: https://github.com/ssb-ngi-pointer/bendy-butt-spec

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ const seed = crypto.randomBytes(32)
 From this seed, a meta feed can be generated using:
 
 ```js
+const salt = 'ssb'
 const prk = hkdf.extract(lhash, hash_len, seed, salt)
 const mf_info = "ssb-meta-feed-seed-v1:metafeed"
 const mf_seed = hkdf.expand(hash, hash_len, prk, length, mf_info)

--- a/meeting-notes-arj-keks-justin-2021-06-15
+++ b/meeting-notes-arj-keks-justin-2021-06-15
@@ -30,6 +30,32 @@ terminology here.
 
 https://github.com/ssb-ngi-pointer/ssb-secure-partial-replication-spec
 
+Notes from Justin:
+
+Claims and Audits
+"...it MIGHT make sense for others to create claims and audit that these claims are indeed valid indexes."
+what is meant by MIGHT? Is this part of the protocol or just an idea? Can this step be omitted?
+
+
+"Because feeds are immutable, once you have verified a feed up until sequence x the past can never change."
+Who is verifying the claim? If bob is verifying Alice's feed, who gave Bob authority. Could Bob not verify until to sequence X, which would prevent Alice's feed from immutability? Ie. Alice could re-write the feed with Bob's help? Or is validation distributed amongst peers?
+
+
+"In order not to create too many verification messages, a new message should only be posted if claim is no longer valid."
+who is creating verification messages? Do I ask verification of my own messages, or do I ask to verify someone else's. If the claim is invalid, does the refer to reopening a claim? Or does this refer to validating a claim?
+
+
+"How often claims should be verified is at the discretion of the auditor."
+Who is the auditor? Who gives them the authority?
+
+
+"It is worth noting that it is limited what a malicious peer could do. The messages in a claim still needs to be signed by the author, so at worst messages can be left out."
+This still amounts to DoS, as messages could be prevented from circulating
+
+
+
+Notes from talk
+
 There were some question around who could audit, also who could change
 an audit (only self). That probably needs a bit of clarification.
 

--- a/meeting-notes-arj-keks-justin-2021-06-15
+++ b/meeting-notes-arj-keks-justin-2021-06-15
@@ -1,0 +1,52 @@
+# Meta feeds & bendy butt spec
+
+Q: should we use a salt value for key derivation?
+
+K: yes, would probably be a good idea. Goes on to explain that it
+would be nice that something like the hmac key could also be derived
+from this, but okay to just use any key and one for the whole network.
+
+Q: Number of random bytes for seed input
+
+K: 32 bytes should be enough
+
+Q: Number of random bytes for nonce
+
+K: As very few keys will be generated one doesn't really need very
+much, we just need them to be unique.
+
+We ended up deciding that 32 bytes would probably also be a good
+number.
+
+Q: Put content & content signature in a box2 encrypted binary field
+
+K: yes
+
+There was a bit confusion about what payload signature and content
+signature ment and which keys signed what. Might be good with common
+terminology here.
+
+# Partial replication spec
+
+https://github.com/ssb-ngi-pointer/ssb-secure-partial-replication-spec
+
+There were some question around who could audit, also who could change
+an audit (only self). That probably needs a bit of clarification.
+
+There was a strong need for a more detailed examples of invalid
+claims. Like what was valid. How can others look and this and see if
+they agree. Should this be machine readable?
+
+For audits only includes latestseq, what feed is that on? The index or
+indexed feed? Probably be better with both.
+
+We talked a bit about these being more like observables, if you only
+write when things change, how do you know if audits are stale? And
+should you only trust the audit up until latestseq?
+
+We talked a bit on the trust model (trustnet) and how to handle
+conflicting audits.
+
+Also talked about incentives, like if most of the network is light
+clients, who will audit? Will that centralise things? Touched on
+hybrid models where you replicate and audit feeds in hops 1.


### PR DESCRIPTION
@cryptix this PR removes `feedformat` from content as that can be deduces from the feed id. Fixes the examples to make that more clear and fixes the nonce to be 32 bytes. I'll get a confirmation on that after my call in about an hour.

Fixes #8 